### PR TITLE
Added docs for error 501 not implemented

### DIFF
--- a/src/Suave/Combinators.fsi
+++ b/src/Suave/Combinators.fsi
@@ -1038,7 +1038,23 @@ module ServerErrors =
   /// from fulfilling the request.
   /// </para></summary>
   val INTERNAL_ERROR : body:string -> WebPart
-
+  
+  /// <summary><para>
+  /// 501
+  /// </para><para>
+  /// The server does not recognize the request method and can not support
+  /// it for any resource.
+  /// </para></summary>
+  val not_implemented : bytes:byte [] -> WebPart
+  
+  /// <summary><para>
+  /// 501
+  /// </para><para>
+  /// The server does not recognize the request method and can not support
+  /// it for any resource.
+  /// </para></summary>
+  val NOT_IMPLEMENTED : body:string [] -> WebPart
+  
   /// An upstream server that suave communicated with did not respond in a timely fashion
   val bad_gateway : bytes:byte [] -> WebPart
 


### PR DESCRIPTION
The method already exists in Combinators.fs, but doesn't show up here. This PR fixes that so that the method and documentation will show up in Intellisense.